### PR TITLE
get the settings from the updated module name

### DIFF
--- a/library/Pnp/ProvidedHook/Grapher.php
+++ b/library/Pnp/ProvidedHook/Grapher.php
@@ -24,7 +24,7 @@ class Grapher extends GrapherHook
 
     protected function init()
     {
-        $cfg = Config::module('pnp4nagios')->getSection('pnp4nagios');
+        $cfg = Config::module('pnp')->getSection('pnp4nagios');
         $this->configDir = rtrim($cfg->get('config_dir', $this->configDir), '/');
         $this->baseUrl   = rtrim($cfg->get('base_url', $this->baseUrl), '/');
         $this->readPnpConfig();


### PR DESCRIPTION
Some distros put the pnp4nagios config directory in a different location (gentoo puts it in /etc/pnp for instance).
This fixes the config not working (only using default values).